### PR TITLE
Fix typos

### DIFF
--- a/src/common/11_authentication.md
+++ b/src/common/11_authentication.md
@@ -96,7 +96,7 @@ The **listeners** have to listen to this event:
 
 # The Firewall (1/2)
 
-Now that you can hook into the application's lifecycle, you can to write a basic
+Now that you can hook into the application's lifecycle, you can write a basic
 but powerful **Firewall**.
 
 This firewall needs a **whitelist** of unsecured routes (i.e. routes that

--- a/src/common/12_writing_better_code.md
+++ b/src/common/12_writing_better_code.md
@@ -232,7 +232,7 @@ It needs to be implemented by the class that wants to use a `BarInterface`:
 
 **I**nversion **o**f **C**ontrol is about who initiates the call. If your code
 initiates a call, it is not IoC, if the container/system/library calls back
-into code that you provided it, is it IoC.
+into code that you provided it, it is IoC.
 
 Hollywood Principle: _Don't call us, we'll call you_.
 


### PR DESCRIPTION
I found 2 small typos.
Congratulations for these amazing slides, this is the way PHP should be taught.
